### PR TITLE
Only run deployment CI workflow on master

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
-name: CI
+name: Deploy
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -11,11 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3
       - name: Push
         env:
           push: ${{ secrets.LOUIS_PUSH }}
         run: | 
           echo "uwu"
-          #git clone https://github.com/niklasCarstensen/Discord-Bot
-          #cd Discord-Bot
           #git push https://$push@git.bre4k3r.de/dev-bre4k3r/Discord-Bot

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ name: Create and publish a Docker image
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
The `pull_request` event fires whenever activity in a PR occurs, which probably wasn't intended for production deployments. This PR fixes this by limiting the workflow to only run when new commits on `master` appear.