### PR TITLE
Make log channel and master user configurable via env vars

### DIFF
--- a/MEE7-Discord-Bot/Backend/Program.cs
+++ b/MEE7-Discord-Bot/Backend/Program.cs
@@ -37,10 +37,11 @@ namespace MEE7
         public static bool RunningOnCI { get; private set; }
         public static bool RunningOnLinux { get; private set; }
 
+        public static readonly ulong logChannel = (ulong.TryParse(Environment.GetEnvironmentVariable("BotLogChannel"), out ulong tmp) ? (ulong?) tmp : null) ??
 #if DEBUG
-        public static readonly ulong logChannel = 714100318656397334;
+            714100318656397334UL;
 #else
-        public static readonly ulong logChannel = 665219921692852271;
+            665219921692852271UL;
 #endif
         public static readonly bool logToDiscord = true;
         public static readonly string instanceIdentifier = "" + Environment.OSVersion + Environment.TickCount64 + Environment.CurrentDirectory;

--- a/MEE7-Discord-Bot/Backend/Program.cs
+++ b/MEE7-Discord-Bot/Backend/Program.cs
@@ -161,9 +161,12 @@ namespace MEE7
             Master = client.GetUser(masterId);
 
             var logMessageChannel = (IMessageChannel)GetChannelFromID(logChannel);
-            if (logMessageChannel != null) {
+            if (logMessageChannel != null)
+            {
                 DiscordNETWrapper.SendText(logStartupMessage, logMessageChannel).Wait();
-            } else {
+            }
+            else
+            {
                 Console.WriteLine($"Cannot access log channel {logChannel} (you can set the environment variable {logChannelEnvVar} to change it!)");
                 Exit(1);
             }


### PR DESCRIPTION
Since the log channel is currently hardcoded, the bot will crash at launch when using a token that cannot access this channel:

```
Error Message: One or more errors occurred. (Object reference not set to an instance of an object.)
Stack Trace:    at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at MEE7.Program.StartUp() in .../MEE7-Discord-Bot/Backend/Program.cs:line 160
   at MEE7.Program.ExecuteBot() in .../MEE7-Discord-Bot/Backend/Program.cs:line 94
   at MEE7.Program.Main() in .../MEE7-Discord-Bot/Backend/Program.cs:line 80
```

To make the project a bit more contributor-friendly, this branch adds two environment variables `BotLogChannel` and `BotMaster`, which can be used to customize the respective channel and user ids. If these variables are unset, the program will fall back to the current values.