### PR TITLE
Wrap log messages to Discord in codeblocks

### DIFF
--- a/MEE7-Discord-Bot/Backend/HelperFunctions/ConsoleWrapper.cs
+++ b/MEE7-Discord-Bot/Backend/HelperFunctions/ConsoleWrapper.cs
@@ -117,7 +117,7 @@ namespace MEE7.Backend.HelperFunctions
             if (Program.logToDiscord)
                 try
                 {
-                    _ = DiscordNETWrapper.SendText(msg.ToString(), Program.logChannel);
+                    _ = DiscordNETWrapper.SendText($"```\n{msg.ToString()}\n```", Program.logChannel);
                 }
                 catch { }
         }


### PR DESCRIPTION
This fixes issues where e.g. backticks in stack traces are mistakenly parsed as Markdown by Discord.