### PR TITLE
Set up Helm chart and Kubernetes deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,18 +1,30 @@
 name: Deploy
 
 on:
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows:
+    - Docker
+    types:
+    - completed
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/checkout@v3
-      - name: Push
-        env:
-          push: ${{ secrets.LOUIS_PUSH }}
-        run: | 
-          echo "uwu"
-          #git push https://$push@git.bre4k3r.de/dev-bre4k3r/Discord-Bot
+    - uses: actions/checkout@v3
+    - name: Set up Kubernetes CLI
+      uses: azure/setup-kubectl@v3
+    - name: Configure Kubernetes context
+      run: |
+        mkdir ~/.kube
+        echo "${{ secrets.PROD_KUBECTL }}" | base64 --decode > ~/.kube/config
+    - name: Set up values
+      run: |
+        mkdir local
+        cat << EOF > local/values.yaml
+        mee7:
+          token: '${{ secrets.BOT_TOKEN }}'
+        EOF
+    - name: Deploy Helm chart
+      run: helm upgrade --install -f local/values.yaml mee7 Helm/mee7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
-name: CI
+name: Deploy
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
     branches: [ master ]
 
 jobs:
@@ -11,11 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3
       - name: Push
         env:
           push: ${{ secrets.LOUIS_PUSH }}
         run: | 
           echo "uwu"
-          #git clone https://github.com/niklasCarstensen/Discord-Bot
-          #cd Discord-Bot
           #git push https://$push@git.bre4k3r.de/dev-bre4k3r/Discord-Bot

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,4 +1,4 @@
-name: Create and publish a Docker image
+name: Docker
 
 on:
   push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,6 @@ name: Create and publish a Docker image
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 env:
   REGISTRY: ghcr.io

--- a/Helm/mee7/.helmignore
+++ b/Helm/mee7/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/Helm/mee7/Chart.yaml
+++ b/Helm/mee7/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "0.1.0"

--- a/Helm/mee7/Chart.yaml
+++ b/Helm/mee7/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: mee7
+description: The MEE7 Discord bot
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.16.0"

--- a/Helm/mee7/templates/_helpers.tpl
+++ b/Helm/mee7/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "mee7.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "mee7.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "mee7.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "mee7.labels" -}}
+helm.sh/chart: {{ include "mee7.chart" . }}
+{{ include "mee7.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "mee7.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "mee7.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/Helm/mee7/templates/deployment.yaml
+++ b/Helm/mee7/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "mee7.fullname" . }}
+  labels:
+    {{- include "mee7.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "mee7.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Make sure that the pods are recreated automatically
+        timestamp: {{ now | quote }}
+      labels:
+        {{- include "mee7.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: "{{ include "mee7.fullname" . }}-secret"
+          env:
+            - name: BotLogChannel
+              value: "{{ .Values.mee7.logChannel }}"
+            - name: BotMaster
+              value: "{{ .Values.mee7.master }}"
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/Helm/mee7/templates/secret.yaml
+++ b/Helm/mee7/templates/secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "{{ include "mee7.fullname" . }}-secret"
+  labels:
+    {{- include "mee7.labels" . | nindent 4 }}
+type: Opaque
+data:
+  BotToken: "{{ .Values.mee7.token | b64enc }}"

--- a/Helm/mee7/values.yaml
+++ b/Helm/mee7/values.yaml
@@ -1,0 +1,35 @@
+# Default values for mee7.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: ghcr.io/jnccd/discord-bot
+  tag: master
+  pullPolicy: Always
+
+mee7:
+  logChannel: '714100318656397334'
+  master: '300699566041202699'
+  # token: 'YOUR_TOKEN'
+
+replicaCount: 1
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+tolerations: []
+affinity: {}


### PR DESCRIPTION
### Based on #7 and #8

This branch adds a Helm chart and a CI workflow that automatically deploys the image to a K8s cluster. For this to work, only a few more steps are needed, namely to configure the following secrets:

- `BOT_TOKEN` should contain the Discord API token
- `PROD_KUBECTL` should contain a base 64-encoded Kubernetes CLI config (e.g. as normally found in `~/.kube/config`) that points to the production cluster and contains the required credentials